### PR TITLE
Allow asset extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,13 @@
 from setuptools import setup, find_packages
 
+with open("README.md") as f:
+    desc = f.read()
+
 setup(
     name="stac-pydantic",
+    description="Pydantic data models for the STAC spec",
+    long_description=desc,
+    long_description_content_type="text/markdown",
     version="1.0.0",
     python_requires=">=3.6",
     classifiers=[

--- a/stac_pydantic/shared.py
+++ b/stac_pydantic/shared.py
@@ -1,7 +1,7 @@
 from enum import auto
 from typing import List, Optional, Tuple, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, Extra
 
 from .utils import AutoValueEnum
 
@@ -80,3 +80,4 @@ class Asset(BaseModel):
     class Config:
         allow_population_by_fieldname = True
         use_enum_values = True
+        extra = Extra.allow

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -323,6 +323,17 @@ def test_invalid_geometry():
     assert "Each linear ring must end where it started" in str(e.value)
 
 
+def test_asset_extras():
+    test_item = request(EO_EXTENSION)
+    for asset in test_item['assets']:
+        test_item['assets'][asset]['foo'] = 'bar'
+
+    item = Item(**test_item)
+    for (asset_name, asset) in item.assets.items():
+        assert asset.foo == 'bar'
+
+
+
 def test_geo_interface():
     test_item = request(EO_EXTENSION)
     item = Item(**test_item)


### PR DESCRIPTION
- Allow assets to have additional fields (ref: https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#asset-object)

> An asset is an object that contains a link to data associated with the Item that can be downloaded or streamed. **It is allowed to add additional fields.**

- Add long description to package