### PR TITLE
release-1.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 PIP_EXTRA_INDEX_URL
-*.txt
 !tests/resources/*.jpg
 **.pyc
 **.log

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,6 @@
+1.0.1 (2020-05-21)
+------------------
+- Allow extra asset-level fields (#1)
+- Fix population by field name model config, allowing model creation without extension namespaces (#2)
+- Add enum of commonly used asset media types (#3)
+- Move geojson models to `geojson-pydantic` library (#4)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description="Pydantic data models for the STAC spec",
     long_description=desc,
     long_description_content_type="text/markdown",
-    version="1.0.0",
+    version="1.0.1",
     python_requires=">=3.6",
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
- Allow extra asset-level fields (#1)
- Fix population by field name model config, allowing model creation without extension namespaces (#2)
- Add enum of commonly used asset media types (#3)
- Move geojson models to `geojson-pydantic` library (#4)