### PR TITLE
add item factory to create model from stac extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ STAC defines many extensions which let the user customize the data in their cata
 implicitly or explicitly:
 
 #### Implicit
-The Catalog/Collection/Item will be validated against the extensions listed in the `stac_extensions` key, if present.
+The `item_model_factory` function creates an appropriate Pydantic model based on the structure of the item by looking
+at the extensions defined by the `stac_extensions` member.
 ```python
-from stac_pydantic import Item
+from stac_pydantic import item_model_factory
 
 stac_item = {
     "type": "Feature",
@@ -53,7 +54,8 @@ stac_item = {
     "assets": ...,
 }
 
-item = Item(**stac_item)
+model = item_model_factory(stac_item)
+item = model(**stac_item)
 
 >>> pydantic.error_wrappers.ValidationError: 1 validation error for Item
     __root__ -> properties -> eo:bands
@@ -61,8 +63,8 @@ item = Item(**stac_item)
 ```
 
 #### Explicit
-You can control which extensions are validated against by explicitly including them in the model.  Implicit extensions
-are validated on top of explicit ones.
+Subclass any of the models provided by the library to explicitly define a model:
+
 ```python
 from stac_pydantic import Item, ItemProperties, Extensions
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ item = model(**stac_item)
 ```
 
 #### Explicit
-Subclass any of the models provided by the library to explicitly define a model:
+Subclass any of the models provided by the library to declare a customized validator:
 
 ```python
 from stac_pydantic import Item, ItemProperties, Extensions

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
+        "pydantic>=1.6",
         "geojson-pydantic"
     ],
     tests_require=[

--- a/stac_pydantic/__init__.py
+++ b/stac_pydantic/__init__.py
@@ -1,4 +1,4 @@
 from .catalog import Catalog
 from .collection import Collection
-from .item import ItemProperties, Item, ItemCollection
+from .item import ItemProperties, Item, ItemCollection, item_model_factory
 from .extensions import Extensions

--- a/stac_pydantic/extensions/datacube.py
+++ b/stac_pydantic/extensions/datacube.py
@@ -23,7 +23,8 @@ class DimensionObject(BaseModel):
     values: Optional[List[Union[NumType, str]]]
     step: Optional[Union[NumType, str]]
     unit: Optional[str]
-    reference_system: Optional[str]
+    reference_system: Optional[int]
+    axis: Optional[str]
 
 
 class HorizontalSpatialDimension(DimensionObject):
@@ -33,7 +34,10 @@ class HorizontalSpatialDimension(DimensionObject):
 
     type: str = Field("spatial", const=True)
     axis: HorizontalAxis
-    extent: Tuple[NumType, NumType]
+    extent: List[NumType]
+
+    class Config:
+        use_enum_values = True
 
 
 class VerticalSpatialDimension(HorizontalSpatialDimension):
@@ -61,10 +65,10 @@ class DatacubeExtension(BaseModel):
     dimensions: Dict[
         str,
         Union[
-            DimensionObject,
             HorizontalSpatialDimension,
             VerticalSpatialDimension,
             TemporalDimension,
+            DimensionObject,
         ],
     ] = Field(..., alias="cube:dimensions")
 

--- a/stac_pydantic/extensions/label.py
+++ b/stac_pydantic/extensions/label.py
@@ -18,7 +18,7 @@ class ClassObject(BaseModel):
     """
 
     name: Optional[Union[str]]
-    classes: Optional[List[Union[str, NumType]]]
+    classes: Optional[List[Union[str, int]]]
 
 
 class CountObject(BaseModel):

--- a/stac_pydantic/extensions/pc.py
+++ b/stac_pydantic/extensions/pc.py
@@ -26,6 +26,9 @@ class SchemaObject(BaseModel):
     size: int
     type: ChannelTypes
 
+    class Config:
+        use_enum_values = True
+
 
 class StatsObject(BaseModel):
     """

--- a/stac_pydantic/extensions/sar.py
+++ b/stac_pydantic/extensions/sar.py
@@ -20,9 +20,6 @@ class Polarizations(BaseModel):
     def __getitem__(self, item):
         return self.__root__[item].value
 
-    class Config:
-        use_enum_values = True
-
 
 class FrequencyBands(str, AutoValueEnum):
     """

--- a/stac_pydantic/extensions/sar.py
+++ b/stac_pydantic/extensions/sar.py
@@ -7,11 +7,21 @@ from ..shared import NumType
 from ..utils import AutoValueEnum
 
 
-class Polarizations(str, AutoValueEnum):
+class PolarizationEnum(str, AutoValueEnum):
     HH = auto()
     VV = auto()
     HV = auto()
     VH = auto()
+
+
+class Polarizations(BaseModel):
+    __root__: List[PolarizationEnum]
+
+    def __getitem__(self, item):
+        return self.__root__[item].value
+
+    class Config:
+        use_enum_values = True
 
 
 class FrequencyBands(str, AutoValueEnum):
@@ -44,9 +54,8 @@ class SARExtension(BaseModel):
     """
 
     instrument_mode: str
-    frequency_band: FrequencyBands
     center_frequency: Optional[NumType]
-    polarizations: List[Polarizations]
+    polarizations: Polarizations
     product_type: str
     resolution_range: Optional[int]
     resolution_azimuth: Optional[int]
@@ -54,10 +63,11 @@ class SARExtension(BaseModel):
     pixel_spacing_azimuth: Optional[int]
     looks_range: Optional[int]
     looks_azimuth: Optional[NumType]
-    looks_equivalent_number: Optional[int]
+    looks_equivalent_number: Optional[NumType]
     observation_direction: Optional[ObservationDirections]
+    frequency_band: FrequencyBands
 
     class Config:
-        use_enum_values = True
         allow_population_by_field_name = True
         alias_generator = lambda field_name: f"sar:{field_name}"
+        use_enum_values = True

--- a/stac_pydantic/extensions/sat.py
+++ b/stac_pydantic/extensions/sat.py
@@ -21,13 +21,10 @@ class SatelliteExtension(BaseModel):
     https://github.com/radiantearth/stac-spec/tree/v0.9.0/extensions/sat#satellite-extension-specification
     """
 
-    orbit_state: Optional[OrbitStates] = Field(None, alias="sat:orbite_state")
-    relative_orbit: Optional[int] = Field(None, alias="sat:relative_orbit")
-    platform: Optional[str]
-    instruments: Optional[List[str]]
-    constellation: Optional[str]
-    mission: Optional[str]
+    orbit_state: Optional[OrbitStates]
+    relative_orbit: Optional[int]
 
     class Config:
         use_enum_values = True
         allow_population_by_field_name = True
+        alias_generator = lambda field_name: f"sat:{field_name}"

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -74,7 +74,9 @@ class ItemCollection(FeatureCollection):
 
 
 @lru_cache
-def _extension_model_factory(stac_extensions: Tuple[str], base_class: Type[Item]):
+def _extension_model_factory(
+    stac_extensions: Tuple[str], base_class: Type[Item]
+) -> Tuple[Type[BaseModel], FieldInfo]:
     """
     Create a stac item properties model for a set of stac extensions
     """
@@ -89,7 +91,10 @@ def _extension_model_factory(stac_extensions: Tuple[str], base_class: Type[Item]
     )
 
 
-def item_factory(item: Dict, base_class: Type[Item] = Item) -> Type[BaseModel]:
+def item_model_factory(item: Dict, base_class: Type[Item] = Item) -> Type[BaseModel]:
+    """
+    Create a pydantic model based on the extensions used by the item
+    """
     item_fields = decompose_model(base_class)
     stac_extensions = item.get("stac_extensions")
 

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -1,21 +1,17 @@
 from datetime import datetime as dt
-from typing import Dict, List, Optional, Union
+from functools import lru_cache
+from typing import Dict, List, Optional, Tuple, Type, Union
 
 from geojson_pydantic.features import Feature, FeatureCollection
-from pydantic import Field, BaseModel, root_validator, ValidationError
+from pydantic import Field, BaseModel, create_model
+from pydantic.fields import FieldInfo
 
 from .shared import Asset, BBox, ExtensionTypes, Link
 from .extensions import Extensions
 from .version import STAC_VERSION
 from .api.extensions.context import ContextExtension
 from .api.extensions.paging import PaginationLink
-
-def _parse_loc(loc):
-    if isinstance(loc, tuple):
-        path = " -> ".join(loc)
-    else:
-        path = loc
-    return f"properties -> {path}"
+from .utils import decompose_model
 
 
 class ItemProperties(BaseModel):
@@ -34,7 +30,6 @@ class ItemProperties(BaseModel):
     constellation: Optional[str] = Field(None, alias="constellation")
     mission: Optional[str] = Field(None, alias="mission")
 
-
     class Config:
         extra = "allow"
 
@@ -52,29 +47,6 @@ class Item(Feature):
     bbox: BBox
     stac_extensions: Optional[List[Union[str, ExtensionTypes]]]
     collection: Optional[str]
-
-    @root_validator(pre=True)
-    def validate_extensions(cls, values):
-        errors = []
-        if "stac_extensions" in values:
-            for ext in values["stac_extensions"]:
-                if ext != "checksum":
-                    ext_model = Extensions.get(ext)
-                    try:
-                        ext_model(**values["properties"])
-                    except ValidationError as e:
-                        raw_errors = e.raw_errors
-                        for error in raw_errors:
-                            if isinstance(error, list):
-                                for err in error[0]:
-                                    err._loc = _parse_loc(err._loc)
-                            else:
-                                error._loc = _parse_loc(error._loc)
-                        errors += e.raw_errors
-        if errors:
-            raise ValidationError(errors=errors, model=Item)
-
-        return values
 
     def to_dict(self, **kwargs):
         return self.dict(by_alias=True, exclude_unset=True, **kwargs)
@@ -99,3 +71,29 @@ class ItemCollection(FeatureCollection):
 
     def to_json(self, **kwargs):
         return self.json(by_alias=True, exclude_unset=True, **kwargs)
+
+
+@lru_cache
+def _extension_model_factory(stac_extensions: Tuple[str]):
+    """
+    Create a stac item properties model for a set of stac extensions
+    """
+    fields = {}
+    for ext in stac_extensions:
+        if ext == "checksum":
+            continue
+        fields.update(decompose_model(Extensions.get(ext)))
+    return (
+        create_model("CustomItemProperties", __base__=ItemProperties, **fields),
+        FieldInfo(...),
+    )
+
+
+def item_factory(item: Dict) -> Type[BaseModel]:
+    item_fields = decompose_model(Item)
+    stac_extensions = item.get("stac_extensions")
+
+    if stac_extensions:
+        item_fields["properties"] = _extension_model_factory(tuple(stac_extensions))
+
+    return create_model("CustomStacItem", **item_fields, __base__=Item)

--- a/stac_pydantic/utils.py
+++ b/stac_pydantic/utils.py
@@ -1,6 +1,14 @@
 from enum import Enum
+from typing import Dict, Type
+
+from pydantic import BaseModel
 
 
 class AutoValueEnum(Enum):
     def _generate_next_value_(name, start, count, last_values):
         return name
+
+
+def decompose_model(model: Type[BaseModel]) -> Dict:
+    """Decompose a pydantic model into a dictionary of model fields"""
+    return {k: (v.outer_type_, v.field_info) for (k, v) in model.__fields__.items()}

--- a/stac_pydantic/utils.py
+++ b/stac_pydantic/utils.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, Type
+from typing import Dict, Optional, Type
 
 from pydantic import BaseModel
 
@@ -11,4 +11,10 @@ class AutoValueEnum(Enum):
 
 def decompose_model(model: Type[BaseModel]) -> Dict:
     """Decompose a pydantic model into a dictionary of model fields"""
-    return {k: (v.outer_type_, v.field_info) for (k, v) in model.__fields__.items()}
+    fields = {}
+    for (k, v) in model.__fields__.items():
+        type = v.outer_type_
+        if not v.required:
+            type = Optional[type]
+        fields[k] = (type, v.field_info)
+    return fields

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,7 @@ import json
 import time
 
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 from shapely.geometry import shape
 
 from stac_pydantic import Collection, Item, ItemCollection, ItemProperties
@@ -558,7 +558,7 @@ def test_declared_model():
             alias_generator = lambda field_name: f"test:{field_name}"
 
     class TestItem(Item):
-        properties = TestProperties
+        properties: TestProperties
 
     test_item = request(EO_EXTENSION)
     del test_item["stac_extensions"]
@@ -572,6 +572,19 @@ def test_declared_model():
 
     assert "test:foo" in valid_item["properties"]
     assert "test:bar" in valid_item["properties"]
+
+
+def test_item_factory_custom_base():
+    class TestProperties(ItemProperties):
+        foo: str = Field("bar", const=True)
+
+    class TestItem(Item):
+        properties: TestProperties
+
+    test_item = request(EO_EXTENSION)
+
+    model = item_factory(test_item, base_class=TestItem)(**test_item)
+    assert model.properties.foo == "bar"
 
 
 def test_serialize_namespace():


### PR DESCRIPTION
There are two ways of validating stac item properties (1) declaring your own model and (2) dynamically validating against the extensions declared in `stac_extensions`.  Previously, both of these use cases were handled in the `stac_pydantic.item.Item` model which led to non-intuitive behavior when validating an item with a `stac_extensions` key while using a declared model.  This behavior happens because the item properties are first loaded into the `ItemProperties` model and then validated against potentially several other extensions (the model used to serialize/de-serialize the data is not the same as those used for validation).

Some examples of this behavior were:
- extension namespaces being overridden (ex. `proj:gsd`).
- not being able to create a model field using its alias (ex. `eo:gsd` would raise a validation error)
- errors in serialization/deserialization (ex. missing extension namespaces)

The library was initially designed this way because pydantic's method for dynamically creating models at runtime (where the signature of the model is based on the data being validated) was not sufficient for our use case.  Recently pydantic has improved this functionality which lets us decouple this logic and overall improve the interface of the library:
1. You can still declare your own model by subclassing `stac_pydantic.item.Item` (with less bugs!).
2. The `stac_pydantic.item.item_factory` method introduced by this PR dynamically creates a subclass of `stac_pydantic.item.Item` but overrides the properties model with a subclass of `stac_pydantic.item.ItemProperties` with additional fields based on the extensions defined by the item.

This PR does not change the fact that extension validation is only explicitly performed on item properties.  This should be implemented in a future PR using a similar strategy.