### PR TITLE
optionally skip remote extensions

### DIFF
--- a/stac_pydantic/scripts/cli.py
+++ b/stac_pydantic/scripts/cli.py
@@ -19,7 +19,7 @@ def validate_item(infile):
     r.raise_for_status()
     stac_item = r.json()
     try:
-        item_model_factory(stac_item)(**stac_item)
+        item_model_factory(stac_item, skip_remote_refs=True)(**stac_item)
     except ValidationError as e:
         click.echo(str(e))
         return

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -614,3 +614,15 @@ def test_register_extension():
 def test_get_missing_extension():
     with pytest.raises(AttributeError):
         Extensions.get("not-an-extension")
+
+
+def test_skip_remote_extension():
+    test_item = request(EO_EXTENSION)
+    test_item["stac_extensions"].append("http://some-remote-extension.json.schema")
+
+    # This should fail
+    with pytest.raises(AttributeError):
+        item_model_factory(test_item, skip_remote_refs=False)(**test_item)
+
+    # This should work
+    item_model_factory(test_item, skip_remote_refs=True)(**test_item)


### PR DESCRIPTION
Validation with `item_model_factory` will fail on remotely referenced extensions unless that extension is defined and registered.  This PR adds the `skip_remote_refs` argument (defaults to `False`) which determines whether or not these extensions are validated.

This is only a temporary fix until we come up with a better strategy for validating remotely referenced extensions.