### PR TITLE
instantiate lru_cache

### DIFF
--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -73,7 +73,7 @@ class ItemCollection(FeatureCollection):
         return self.json(by_alias=True, exclude_unset=True, **kwargs)
 
 
-@lru_cache
+@lru_cache()
 def _extension_model_factory(
     stac_extensions: Tuple[str], base_class: Type[Item], skip_remote_refs: bool = False
 ) -> Tuple[Type[BaseModel], FieldInfo]:


### PR DESCRIPTION
Thanks for catching this @francbartoli!

The error for reference:
```
TypeError                                 Traceback (most recent call last)
<ipython-input-1-6e8802b290cd> in <module>
----> 1 from stac_pydantic import Catalog

~/.pyenv/versions/3.7.6/envs/pygeoapi/lib/python3.7/site-packages/stac_pydantic/__init__.py in <module>
      2 from .collection import Collection
      3 from .extensions import Extensions
----> 4 from .item import (
      5     Item,
      6     ItemCollection,

~/.pyenv/versions/3.7.6/envs/pygeoapi/lib/python3.7/site-packages/stac_pydantic/item.py in <module>
     77 def _extension_model_factory(
     78     stac_extensions: Tuple[str], base_class: Type[Item], skip_remote_refs: bool = False
---> 79 ) -> Tuple[Type[BaseModel], FieldInfo]:
     80     """
     81     Create a stac item properties model for a set of stac extensions

~/.pyenv/versions/3.7.6/lib/python3.7/functools.py in lru_cache(maxsize, typed)
    488             maxsize = 0
    489     elif maxsize is not None:
--> 490         raise TypeError('Expected maxsize to be an integer or None')
    491
    492     def decorating_function(user_function):

TypeError: Expected maxsize to be an integer or None
```