### PR TITLE
remove stac_extensions enum requirement

### DIFF
--- a/stac_pydantic/catalog.py
+++ b/stac_pydantic/catalog.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from pydantic import BaseModel, Field, root_validator
 
 from .extensions import Extensions
-from .shared import ExtensionTypes, Link
+from .shared import Link
 from .version import STAC_VERSION
 
 
@@ -16,7 +16,7 @@ class Catalog(BaseModel):
     description: str
     stac_version: str = Field(STAC_VERSION, const=True)
     links: List[Link]
-    stac_extensions: Optional[List[ExtensionTypes]]
+    stac_extensions: Optional[List[str]]
     title: Optional[str]
 
     class Config:

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -9,7 +9,7 @@ from pydantic.fields import FieldInfo
 from .api.extensions.context import ContextExtension
 from .api.extensions.paging import PaginationLink
 from .extensions import Extensions
-from .shared import Asset, BBox, ExtensionTypes, Link, StacCommonMetadata
+from .shared import Asset, BBox, Link, StacCommonMetadata
 from .utils import decompose_model
 from .version import STAC_VERSION
 
@@ -45,7 +45,7 @@ class Item(Feature):
     assets: Dict[str, Asset]
     links: List[Link]
     bbox: BBox
-    stac_extensions: Optional[List[Union[str, ExtensionTypes]]]
+    stac_extensions: Optional[List[str]]
     collection: Optional[str]
 
     def to_dict(self, **kwargs):
@@ -62,7 +62,7 @@ class ItemCollection(FeatureCollection):
 
     stac_version: str = Field(STAC_VERSION, const=True)
     features: List[Item]
-    stac_extensions: Optional[List[ExtensionTypes]]
+    stac_extensions: Optional[List[str]]
     links: List[Union[PaginationLink, Link]]
     context: Optional[ContextExtension]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -630,3 +630,16 @@ def test_multi_inheritance():
     assert "gsd" in properties
     assert "view:off_nadir" in properties
     assert "landsat:path" in properties
+
+
+def test_extension():
+    test_item = request(EO_EXTENSION)
+    test_item["stac_extensions"].append("foo")
+
+    item = Item.parse_obj(test_item)
+    assert "foo" in item.stac_extensions
+
+    test_collection = request(COLLECTION)
+    test_collection["stac_extensions"].append("foo")
+    collection = Collection.parse_obj(test_collection)
+    assert "foo" in collection.stac_extensions

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -632,14 +632,9 @@ def test_multi_inheritance():
     assert "landsat:path" in properties
 
 
-def test_extension():
-    test_item = request(EO_EXTENSION)
-    test_item["stac_extensions"].append("foo")
-
-    item = Item.parse_obj(test_item)
-    assert "foo" in item.stac_extensions
-
-    test_collection = request(COLLECTION)
-    test_collection["stac_extensions"].append("foo")
-    collection = Collection.parse_obj(test_collection)
-    assert "foo" in collection.stac_extensions
+@pytest.mark.parametrize("url,cls", [[EO_EXTENSION, Item], [COLLECTION, Collection]])
+def test_extension(url, cls):
+    test_data = request(url)
+    test_data["stac_extensions"].append("foo")
+    model = cls.parse_obj(test_data)
+    assert "foo" in model.stac_extensions


### PR DESCRIPTION
This PR removes the `ExtensionTypes` enum requirement from `stac_extensions` members.  Strict validation of `stac_extensions` against the spec (or really any set of extensions) is sometimes useful, but it shouldn't be the default behavior as it is quite restrictive.  If a user wants to strictly validate extension types, they can subclass the pydantic model.