### PR TITLE
Add 'id' to LandPage to make it a valid Catalog.

### DIFF
--- a/stac_pydantic/api/landing.py
+++ b/stac_pydantic/api/landing.py
@@ -11,6 +11,7 @@ class LandingPage(BaseModel):
     https://github.com/radiantearth/stac-api-spec/blob/master/api-spec.md#ogc-api---features-endpoints
     """
 
+    id: str
     description: str
     title: Optional[str]
     stac_version: str = Field(STAC_VERSION, const=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import BaseModel, Field, ValidationError
 from shapely.geometry import shape
 
-from stac_pydantic import Collection, Item, ItemCollection, ItemProperties
+from stac_pydantic import Catalog, Collection, Item, ItemCollection, ItemProperties
 from stac_pydantic.api.conformance import ConformanceClasses
 from stac_pydantic.api.extensions.paging import PaginationLink
 from stac_pydantic.api.landing import LandingPage
@@ -335,10 +335,20 @@ def test_api_conformance_invalid_url():
 
 def test_api_landing_page():
     LandingPage(
+        id='test-landing-page',
         description="stac-api landing page",
         stac_extensions=["eo", "proj"],
         links=[Link(href="http://link", rel="self",)],
     )
+
+def test_api_landing_page_is_catalog():
+    landing_page = LandingPage(
+        id='test-landing-page',
+        description="stac-api landing page",
+        stac_extensions=["eo", "proj"],
+        links=[Link(href="http://link", rel="self",)],
+    )
+    catalog = Catalog(**landing_page.dict())
 
 
 def test_search():


### PR DESCRIPTION
This PR adds an `id` field to LandingPage in order to make it a valid catalog.

Fixes #42 


Note that I ran into https://github.com/developmentseed/geojson-pydantic/issues/14 while trying to run tests - not sure what the issue was there, but installing geojson-pydantic from source in my virtualenv got me past it.