### PR TITLE
add link factories

### DIFF
--- a/stac_pydantic/api/utils/link_factory.py
+++ b/stac_pydantic/api/utils/link_factory.py
@@ -1,6 +1,6 @@
 import inspect
 from dataclasses import dataclass
-from typing import List, get_type_hints
+from typing import List
 from urllib.parse import urljoin
 
 from ...links import Link, Relations

--- a/stac_pydantic/api/utils/link_factory.py
+++ b/stac_pydantic/api/utils/link_factory.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import List
 from urllib.parse import urljoin
 
-from ...links import Link, Relations
+from ...links import Link, Links, Relations
 from ...shared import MimeTypes
 
 
@@ -20,17 +20,18 @@ class BaseLinks:
             rel=Relations.root, type=MimeTypes.json, href=urljoin(self.base_url, "/")
         )
 
-    def create_links(self) -> List[Link]:
+    def create_links(self) -> Links:
         """Create inferred links"""
         links = []
         methods = inspect.getmembers(self, predicate=inspect.ismethod)
         for method in methods:
             func = method[-1]
             ret_type = inspect.signature(func).return_annotation
+            # TODO: enforce full signature
             if inspect.isclass(ret_type):
                 if issubclass(ret_type, Link):
                     links.append(func())
-        return links
+        return Links.parse_obj(links)
 
 
 @dataclass

--- a/stac_pydantic/api/utils/link_factory.py
+++ b/stac_pydantic/api/utils/link_factory.py
@@ -1,0 +1,94 @@
+from dataclasses import dataclass
+from typing import List
+from urllib.parse import urljoin
+
+from ...links import Link, Relations
+from ...shared import MimeTypes
+
+
+@dataclass
+class BaseLinks:
+    """Create inferred links common to collections and items."""
+
+    base_url: str
+    collection_id: str
+
+    def root(self) -> Link:
+        """Return the catalog root."""
+        return Link(
+            rel=Relations.root, type=MimeTypes.json, href=urljoin(self.base_url, "/")
+        )
+
+
+@dataclass
+class CollectionLinks(BaseLinks):
+    """Create inferred links specific to collections."""
+
+    def self(self) -> Link:
+        """Create the `self` link."""
+        return Link(
+            rel=Relations.self,
+            type=MimeTypes.json,
+            href=urljoin(self.base_url, f"/collections/{self.collection_id}"),
+        )
+
+    def parent(self) -> Link:
+        """Create the `parent` link."""
+        return Link(
+            rel=Relations.parent, type=MimeTypes.json, href=urljoin(self.base_url, "/")
+        )
+
+    def item(self) -> Link:
+        """Create the `item` link."""
+        return Link(
+            rel=Relations.item,
+            type=MimeTypes.geojson,
+            href=urljoin(self.base_url, f"/collections/{self.collection_id}/items"),
+        )
+
+    def create_links(self) -> List[Link]:
+        """Return all inferred links."""
+        return [self.self(), self.parent(), self.item(), self.root()]
+
+
+@dataclass
+class ItemLinks(BaseLinks):
+    """Create inferred links specific to items."""
+
+    item_id: str
+
+    def self(self) -> Link:
+        """Create the `self` link."""
+        return Link(
+            rel=Relations.self,
+            type=MimeTypes.geojson,
+            href=urljoin(
+                self.base_url, f"/collections/{self.collection_id}/items/{self.item_id}"
+            ),
+        )
+
+    def parent(self) -> Link:
+        """Create the `parent` link."""
+        return Link(
+            rel=Relations.parent,
+            type=MimeTypes.json,
+            href=urljoin(self.base_url, f"/collections/{self.collection_id}"),
+        )
+
+    def collection(self) -> Link:
+        """Create the `collection` link."""
+        return Link(
+            rel=Relations.collection,
+            type=MimeTypes.json,
+            href=urljoin(self.base_url, f"/collections/{self.collection_id}"),
+        )
+
+    def create_links(self) -> List[Link]:
+        """Return all inferred links."""
+        links = [
+            self.self(),
+            self.parent(),
+            self.collection(),
+            self.root(),
+        ]
+        return links

--- a/stac_pydantic/api/utils/link_factory.py
+++ b/stac_pydantic/api/utils/link_factory.py
@@ -11,7 +11,6 @@ class BaseLinks:
     """Create inferred links common to collections and items."""
 
     base_url: str
-    collection_id: str
     _link_members: ClassVar[Tuple[str]] = ("root")
 
     def root(self) -> Link:
@@ -31,6 +30,7 @@ class BaseLinks:
 class CollectionLinks(BaseLinks):
     """Create inferred links specific to collections."""
 
+    collection_id: str
     _link_members: ClassVar[Tuple[str]] = ("root", "self", "parent", "item")
 
     def self(self) -> Link:
@@ -60,6 +60,7 @@ class CollectionLinks(BaseLinks):
 class ItemLinks(BaseLinks):
     """Create inferred links specific to items."""
 
+    collection_id: str
     item_id: str
     _link_members: ClassVar[Tuple[str]] = ("root", "self", "parent", "collection")
 

--- a/stac_pydantic/api/utils/link_factory.py
+++ b/stac_pydantic/api/utils/link_factory.py
@@ -1,4 +1,3 @@
-import inspect
 from dataclasses import dataclass
 from typing import ClassVar, Tuple
 from urllib.parse import urljoin
@@ -23,7 +22,9 @@ class BaseLinks:
 
     def create_links(self) -> Links:
         """Create inferred links"""
-        return Links.parse_obj([getattr(self, member) for member in self._link_members])
+        return Links.parse_obj(
+            [getattr(self, member)() for member in self._link_members]
+        )
 
 
 @dataclass

--- a/stac_pydantic/links.py
+++ b/stac_pydantic/links.py
@@ -70,6 +70,12 @@ class Links(BaseModel):
         """iterate through links"""
         return iter(self.__root__)
 
+    def __len__(self):
+        return len(self.__root__)
+
+    def __getitem__(self, idx):
+        return self.__root__[idx]
+
 
 class Relations(str, AutoValueEnum):
     """

--- a/tests/test_link_factory.py
+++ b/tests/test_link_factory.py
@@ -1,4 +1,7 @@
-from stac_pydantic.api.utils.link_factory import CollectionLinks, ItemLinks
+from typing import ClassVar, Tuple
+from urllib.parse import urljoin
+
+from stac_pydantic.api.utils.link_factory import BaseLinks, CollectionLinks, ItemLinks
 from stac_pydantic.links import Link
 
 
@@ -18,3 +21,21 @@ def test_item_links():
     for link in links:
         assert isinstance(link, Link)
         assert link.rel in ItemLinks._link_members
+
+
+def test_custom_links():
+    class CustomLinks(BaseLinks):
+        _link_members: ClassVar[Tuple[str]] = ("another_link",)
+
+        def another_link(self) -> Link:
+            return Link(
+                rel="another-link",
+                type="application/json",
+                href=urljoin(self.base_url, "/another-link"),
+            )
+
+    links = CustomLinks(base_url="http://stac.com").create_links()
+    assert len(links) == 1
+    assert links[0].rel == "another-link"
+    assert links[0].type == "application/json"
+    assert links[0].href == "http://stac.com/another-link"

--- a/tests/test_link_factory.py
+++ b/tests/test_link_factory.py
@@ -1,0 +1,20 @@
+from stac_pydantic.api.utils.link_factory import CollectionLinks, ItemLinks
+from stac_pydantic.links import Link
+
+
+def test_collection_links():
+    links = CollectionLinks(
+        collection_id="collection", base_url="http://stac.com"
+    ).create_links()
+    for link in links:
+        assert isinstance(link, Link)
+        assert link.rel in CollectionLinks._link_members
+
+
+def test_item_links():
+    links = ItemLinks(
+        collection_id="collection", item_id="item", base_url="http://stac.com"
+    ).create_links()
+    for link in links:
+        assert isinstance(link, Link)
+        assert link.rel in ItemLinks._link_members


### PR DESCRIPTION
- Adds some classes that make it easier to generate inferred links.
- The `BaseLinks.create_links` method will include any method that (1) takes no arguments and (2) returns a `stac_pydantic.links.Link` object, allowing the caller to add their own inferred links through inheritance.
- Should rename these classes to make it clearer these are for _inferred_ links.