### PR TITLE
serialize datetimes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md") as f:
     desc = f.read()
 
 extras = {
-    "dev": ["pytest", "pytest-cov", "requests", "shapely", "dictdiffer"],
+    "dev": ["arrow", "pytest", "pytest-cov", "requests", "shapely", "dictdiffer"],
 }
 
 setup(

--- a/stac_pydantic/api/search.py
+++ b/stac_pydantic/api/search.py
@@ -34,6 +34,24 @@ class Search(BaseModel):
     query: Optional[Dict[str, Dict[Operator, Any]]]
     sortby: Optional[List[SortExtension]]
 
+    @property
+    def start_date(self):
+        values = self.datetime.split("/")
+        if len(values) == 1:
+            return None
+        if values[0] == "..":
+            return None
+        return datetime.strptime(values[0], DATETIME_RFC339)
+
+    @property
+    def end_date(self):
+        values = self.datetime.split("/")
+        if len(values) == 1:
+            return datetime.strptime(values[0], DATETIME_RFC339)
+        if values[1] == "..":
+            return None
+        return datetime.strptime(values[1], DATETIME_RFC339)
+
     @validator("intersects")
     def validate_spatial(cls, v, values):
         if v and values["bbox"]:
@@ -68,5 +86,4 @@ class Search(BaseModel):
                 raise ValueError(
                     "Invalid datetime range, must match format (begin_date, end_date)"
                 )
-
-        return dates
+        return v

--- a/stac_pydantic/api/search.py
+++ b/stac_pydantic/api/search.py
@@ -35,7 +35,7 @@ class Search(BaseModel):
     sortby: Optional[List[SortExtension]]
 
     @property
-    def start_date(self):
+    def start_date(self) -> Optional[datetime]:
         values = self.datetime.split("/")
         if len(values) == 1:
             return None
@@ -44,7 +44,7 @@ class Search(BaseModel):
         return datetime.strptime(values[0], DATETIME_RFC339)
 
     @property
-    def end_date(self):
+    def end_date(self) -> Optional[datetime]:
         values = self.datetime.split("/")
         if len(values) == 1:
             return datetime.strptime(values[0], DATETIME_RFC339)

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -30,7 +30,7 @@ class ItemProperties(StacCommonMetadata):
                 )
 
         if isinstance(v, str):
-            return dt.strptime(v, DATETIME_RFC339)
+            return cls._parse_rfc3339(v)
 
         return v
 

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -9,7 +9,7 @@ from pydantic.fields import FieldInfo
 from stac_pydantic.api.extensions.context import ContextExtension
 from stac_pydantic.extensions import Extensions
 from stac_pydantic.links import Links
-from stac_pydantic.shared import Asset, BBox, StacCommonMetadata
+from stac_pydantic.shared import DATETIME_RFC339, Asset, BBox, StacCommonMetadata
 from stac_pydantic.utils import decompose_model
 from stac_pydantic.version import STAC_VERSION
 
@@ -19,7 +19,7 @@ class ItemProperties(StacCommonMetadata):
     https://github.com/radiantearth/stac-spec/blob/v1.0.0-beta.1/item-spec/item-spec.md#properties-object
     """
 
-    datetime: Union[str, dt] = Field(..., alias="datetime")
+    datetime: Union[dt, str] = Field(..., alias="datetime")
 
     @validator("datetime")
     def validate_datetime(cls, v, values):
@@ -28,10 +28,15 @@ class ItemProperties(StacCommonMetadata):
                 raise ValueError(
                     "start_datetime and end_datetime must be specified when datetime is null"
                 )
+
+        if isinstance(v, str):
+            return dt.strptime(v, DATETIME_RFC339)
+
         return v
 
     class Config:
         extra = "allow"
+        json_encoders = {dt: lambda v: v.strftime(DATETIME_RFC339)}
 
 
 class Item(Feature):

--- a/stac_pydantic/shared.py
+++ b/stac_pydantic/shared.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import List, Optional, Tuple, Union
 
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, Extra, Field, validator
 
 from stac_pydantic.extensions.eo import BandObject
 from stac_pydantic.utils import AutoValueEnum
@@ -101,16 +101,35 @@ class StacCommonMetadata(BaseModel):
 
     title: Optional[str] = Field(None, alias="title")
     description: Optional[str] = Field(None, alias="description")
-    start_datetime: Optional[Union[str, datetime]] = Field(None, alias="start_datetime")
-    end_datetime: Optional[Union[str, datetime]] = Field(None, alias="end_datetime")
-    created: Optional[Union[str, datetime]] = Field(None, alias="created")
-    updated: Optional[Union[str, datetime]] = Field(None, alias="updated")
+    start_datetime: Optional[Union[datetime, str]] = Field(None, alias="start_datetime")
+    end_datetime: Optional[Union[datetime, str]] = Field(None, alias="end_datetime")
+    created: Optional[Union[datetime, str]] = Field(None, alias="created")
+    updated: Optional[Union[datetime, str]] = Field(None, alias="updated")
     platform: Optional[str] = Field(None, alias="platform")
     instruments: Optional[List[str]] = Field(None, alias="instruments")
     constellation: Optional[str] = Field(None, alias="constellation")
     mission: Optional[str] = Field(None, alias="mission")
     providers: Optional[List[Provider]] = Field(None, alias="providers")
     gsd: Optional[NumType] = Field(None, alias="gsd")
+
+    @validator("start_datetime", allow_reuse=True)
+    def validate_start_datetime(cls, v):
+        return datetime.strptime(v, DATETIME_RFC339)
+
+    @validator("end_datetime", allow_reuse=True)
+    def validate_start_datetime(cls, v):
+        return datetime.strptime(v, DATETIME_RFC339)
+
+    @validator("created", allow_reuse=True)
+    def validate_start_datetime(cls, v):
+        return datetime.strptime(v, DATETIME_RFC339)
+
+    @validator("updated", allow_reuse=True)
+    def validate_start_datetime(cls, v):
+        return datetime.strptime(v, DATETIME_RFC339)
+
+    class Config:
+        json_encoders = {datetime: lambda v: v.strftime(DATETIME_RFC339)}
 
 
 class Asset(StacCommonMetadata):

--- a/stac_pydantic/shared.py
+++ b/stac_pydantic/shared.py
@@ -112,21 +112,30 @@ class StacCommonMetadata(BaseModel):
     providers: Optional[List[Provider]] = Field(None, alias="providers")
     gsd: Optional[NumType] = Field(None, alias="gsd")
 
+    @staticmethod
+    def _parse_rfc3339(dt: str):
+        try:
+            return datetime.strptime(dt, DATETIME_RFC339)
+        except Exception as e:
+            raise ValueError(
+                f"Invalid datetime, must match format ({DATETIME_RFC339})."
+            ) from e
+
     @validator("start_datetime", allow_reuse=True)
     def validate_start_datetime(cls, v):
-        return datetime.strptime(v, DATETIME_RFC339)
+        return cls._parse_rfc3339(v)
 
     @validator("end_datetime", allow_reuse=True)
     def validate_start_datetime(cls, v):
-        return datetime.strptime(v, DATETIME_RFC339)
+        return cls._parse_rfc3339(v)
 
     @validator("created", allow_reuse=True)
     def validate_start_datetime(cls, v):
-        return datetime.strptime(v, DATETIME_RFC339)
+        return cls._parse_rfc3339(v)
 
     @validator("updated", allow_reuse=True)
     def validate_start_datetime(cls, v):
-        return datetime.strptime(v, DATETIME_RFC339)
+        return cls._parse_rfc3339(v)
 
     class Config:
         json_encoders = {datetime: lambda v: v.strftime(DATETIME_RFC339)}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,13 @@
+import operator
+from datetime import datetime, timedelta
+
+import arrow
 import dictdiffer
 import pytest
 import requests
 from click.testing import CliRunner
+
+from stac_pydantic.shared import DATETIME_RFC339
 
 
 def request(url: str):
@@ -19,6 +25,15 @@ def dict_match(d1: dict, d2: dict):
         # same for bbox
         elif "bbox" in diff[1]:
             assert list(diff[2][0]) == list(diff[2][1])
+        # test data is pretty variable with how it represents datetime, RFC3339 is quite flexible
+        # but stac-pydantic only supports a single datetime format, so just validate to the day.
+        elif "datetime" in diff[1]:
+            dates = []
+            for date in diff[2]:
+                if isinstance(date, str):
+                    date = arrow.get(date)
+                dates.append(date)
+            assert operator.sub(*dates).days == 0
         # any other differences are errors
         else:
             raise AssertionError("Unexpected difference: ", diff)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -203,13 +203,13 @@ def test_to_json(infile, model):
             feat["stac_version"] = STAC_VERSION
 
     validated = model(**test_item)
-    assert validated.to_json() == json.dumps(validated.to_dict())
+    dict_match(json.loads(validated.to_json()), validated.to_dict())
 
 
 def test_item_to_json():
     test_item = request(EO_EXTENSION)
     item = Item(**test_item)
-    assert item.to_json() == json.dumps(item.to_dict())
+    dict_match(json.loads(item.to_json()), item.to_dict())
 
 
 def test_datacube_extension_validation_error():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -395,26 +395,31 @@ def test_invalid_spatial_search():
         )
 
 
-def test_temporal_search():
+def test_temporal_search_single_tailed():
     # Test single tailed
-    utcnow = datetime.utcnow().strftime(DATETIME_RFC339)
-    search = Search(collections=["collection1"], datetime=utcnow)
-    assert len(search.datetime) == 2
-    assert search.datetime == ["..", utcnow]
+    utcnow = datetime.utcnow().replace(microsecond=0)
+    utcnow_str = utcnow.strftime(DATETIME_RFC339)
+    search = Search(collections=["collection1"], datetime=utcnow_str)
+    assert search.start_date == None
+    assert search.end_date == utcnow
 
+
+def test_temporal_search_two_tailed():
     # Test two tailed
-    search = Search(collections=["collection1"], datetime=f"{utcnow}/{utcnow}")
-    assert len(search.datetime) == 2
-    assert search.datetime == [utcnow, utcnow]
+    utcnow = datetime.utcnow().replace(microsecond=0)
+    utcnow_str = utcnow.strftime(DATETIME_RFC339)
+    search = Search(collections=["collection1"], datetime=f"{utcnow_str}/{utcnow_str}")
+    assert search.start_date == search.end_date == utcnow
 
-    search = Search(collections=["collection1"], datetime=f"{utcnow}/..")
-    assert len(search.datetime) == 2
-    assert search.datetime == [utcnow, ".."]
+    search = Search(collections=["collection1"], datetime=f"{utcnow_str}/..")
+    assert search.start_date == utcnow
+    assert search.end_date == None
 
+
+def test_temporal_search_open():
     # Test open date range
-    search = Search(collections=["collection1"], datetime=f"../..")
-    assert len(search.datetime) == 2
-    assert search.datetime == ["..", ".."]
+    search = Search(collections=["collection1"], datetime="../..")
+    assert search.start_date == search.end_date == None
 
 
 def test_invalid_temporal_search():


### PR DESCRIPTION
Store date information in the model using a `datetime.datetime` object where appropriate:
- `Item.properties.datetime`
- `Item.properties.start_datetime`
- `Item.properties.end_datetime`
- `Item.properties.created`
- `Item.properties.updated`

I've also updated the `Search` model.  `Search.datetime` is defined as a date string with potentially two dates (separated by a `/`).  Because the field on the model is typed as `str`, it doesn't feel right to coerce the type to `List[Union[datetime, str]]` because that conflicts with the defined type.  So instead I've added `start_datetime` and `end_datetime` properties which both return `Optional[datetime]`.

Closes #49 